### PR TITLE
{cmd,bin}: adds ./bin/update-paths.sh

### DIFF
--- a/bin/update-paths.sh
+++ b/bin/update-paths.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go run ./cmd/replace-paths/replace-paths.go

--- a/cmd/replace-paths/replace-paths.go
+++ b/cmd/replace-paths/replace-paths.go
@@ -1,7 +1,117 @@
 package main
 
-import "log"
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 func main() {
-  log.Println("ok")
+	rp := ReplacePaths{}
+	result, err := rp.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println(result)
+}
+
+const rootDir string = "./"
+
+type ReplacePaths struct{}
+
+func (rp *ReplacePaths) Run() ([]string, error) {
+	goFiles, err := rp.readGoFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	fileImports, err := rp.readAllFileImports(goFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	importPaths := []string{}
+	for _, fileImport := range fileImports {
+		importPaths = append(importPaths, fileImport)
+	}
+
+	return importPaths, nil
+}
+
+func (rp *ReplacePaths) readGoFiles() ([]string, error) {
+	files := []string{}
+
+	walk := func(s string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(s, ".go") {
+			files = append(files, s)
+		}
+
+		return nil
+	}
+
+	filepath.WalkDir(rootDir, walk)
+
+	return files, nil
+}
+
+func (rp *ReplacePaths) readAllFileImports(testFiles []string) ([]string, error) {
+	result := []string{}
+
+	for _, filePath := range testFiles {
+		funcNames, err := rp.readFileImports(filePath)
+		if err != nil {
+			return result, err
+		}
+
+		result = append(result, funcNames...)
+	}
+
+	return result, nil
+}
+
+func (rp *ReplacePaths) readFileImports(filePath string) ([]string, error) {
+	goFile, err := rp.readFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer goFile.Close()
+
+	funcNames := []string{}
+	fset := token.NewFileSet()
+	astFile, err := parser.ParseFile(fset, "", goFile, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, decl := range astFile.Decls {
+		switch t := decl.(type) {
+		case *ast.FuncDecl:
+			funcNames = append(funcNames, t.Name.Name)
+		}
+	}
+
+	return funcNames, nil
+}
+
+func (rp *ReplacePaths) readFile(filePath string) (*os.File, error) {
+	goFile, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return goFile, nil
 }

--- a/cmd/replace-paths/replace-paths.go
+++ b/cmd/replace-paths/replace-paths.go
@@ -90,7 +90,7 @@ func (rp *ReplacePaths) readFileImports(filePath string) ([]string, error) {
 	}
 	defer goFile.Close()
 
-	funcNames := []string{}
+	declNames := []string{}
 	fset := token.NewFileSet()
 	astFile, err := parser.ParseFile(fset, "", goFile, parser.ParseComments)
 	if err != nil {
@@ -99,12 +99,25 @@ func (rp *ReplacePaths) readFileImports(filePath string) ([]string, error) {
 
 	for _, decl := range astFile.Decls {
 		switch t := decl.(type) {
-		case *ast.FuncDecl:
-			funcNames = append(funcNames, t.Name.Name)
+		case *ast.GenDecl:
+			if t.Tok.String() == "import" {
+				for _, spec := range t.Specs {
+					switch s := spec.(type) {
+					case *ast.ImportSpec:
+						if s.Path != nil {
+							v := s.Path.Value
+							log.Println(v)
+							// TODO(@chris-ramon).
+							// GitHub Issue: To be completed.
+						}
+					}
+				}
+			}
+
 		}
 	}
 
-	return funcNames, nil
+	return declNames, nil
 }
 
 func (rp *ReplacePaths) readFile(filePath string) (*os.File, error) {

--- a/cmd/replace-paths/replace-paths.go
+++ b/cmd/replace-paths/replace-paths.go
@@ -1,0 +1,7 @@
+package main
+
+import "log"
+
+func main() {
+  log.Println("ok")
+}


### PR DESCRIPTION
#### Details
- `bin`: adds `update-paths.sh` script.
- `cmd`: adds `replace-paths` pkg.

#### Test Plan
- Created an issue to complete the last part of path replacement: https://github.com/chris-ramon/golang-scaffolding/issues/6.